### PR TITLE
[UEPR-17] Changed entry point name

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,12 +2,12 @@
   "name": "scratch-svg-renderer",
   "version": "2.3.74",
   "description": "SVG renderer for Scratch",
-  "main": "./dist/node/ScratchSVGRenderer.js",
-  "browser": "./dist/web/ScratchSVGRenderer.js",
+  "main": "./dist/node/scratch-svg-renderer.js",
+  "browser": "./dist/web/scratch-svg-renderer.js",
   "exports": {
     "webpack": "./src/index.js",
-    "browser": "./dist/web/ScratchSVGRenderer.js",
-    "node": "./dist/node/ScratchSVGRenderer.js",
+    "browser": "./dist/web/scratch-svg-renderer.js",
+    "node": "./dist/node/scratch-svg-renderer.js",
     "default": "./src/index.js"
   },
   "scripts": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,7 +3,7 @@ const path = require('path');
 const ScratchWebpackConfigBuilder = require('scratch-webpack-configuration');
 
 const common = {
-    libraryName: 'ScratchSVGRenderer',
+    libraryName: 'scratch-svg-renderer',
     rootPath: path.resolve(__dirname)
 };
 
@@ -12,6 +12,14 @@ const common = {
  */
 const nodeConfig = new ScratchWebpackConfigBuilder(common)
     .setTarget('node')
+    .merge({
+        output: {
+            library: {
+                name: 'ScratchSVGRenderer',
+                type: 'umd'
+            }
+        }
+    })
     .get();
 
 /**
@@ -19,6 +27,14 @@ const nodeConfig = new ScratchWebpackConfigBuilder(common)
  */
 const webConfig = new ScratchWebpackConfigBuilder(common)
     .setTarget('browserslist')
+    .merge({
+        output: {
+            library: {
+                name: 'ScratchSVGRenderer',
+                type: 'umd'
+            }
+        }
+    })
     .get();
 
 /**
@@ -33,6 +49,10 @@ const playgroundConfig = new ScratchWebpackConfigBuilder(common)
         },
         output: {
             path: path.resolve(__dirname, 'playground'),
+            library: {
+                name: 'ScratchSVGRenderer',
+                type: 'umd'
+            },
             publicPath: '/'
         }
     })


### PR DESCRIPTION
### Jira Ticket
[UEPR-17](https://scratchfoundation.atlassian.net/browse/UEPR-17)

### Proposed Changes
Changed entry point name because this is what it was prior using the template webpack configurations and other applications use it.

### Test Coverage
Tests scratch-render, scratch-vm and scratch-gui tests are passing when linked scratch-svg-renderer.